### PR TITLE
Issue #5 Adding pre-commit hook and instructions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# What are we doing
+printf "\e[1;93mRunning pre-commit hooks...\e[0;39m \n"
+
+# Our failure flag
+FAILURE=false
+
+# Get staged go files that we want to run checks on
+STAGED_FILES=$(git ls-files --full-name | grep ".go$")
+
+if [[ "$STAGED_FILES" = "" ]]; then
+  exit 0
+fi
+printf "\e[90mRunning golint...\e[0;39m\n"
+# Run go lint on the staged files
+for stagedFile in $STAGED_FILES; do
+    # Run golint
+    $(golint -set_exit_status $stagedFile)
+    if [[ $? != 0 ]]; then
+        FAILURE=true
+    fi
+done
+
+# Run go vet on the entire package, doesn't support single files like lint
+printf "\e[90mRunning go vet...\e[0;39m\n"
+go vet $STAGED_FILES
+if [[ $? != 0 ]]; then
+    FAILURE=true
+fi
+
+printf "\e[90mDone! \n"
+
+if [[ $FAILURE != false ]]; then
+    printf "\n\e[91mCommit Failed! \n"
+    exit 1
+fi
+
+printf "\n\e[32mCommit Successful! \n"
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,8 +12,9 @@ STAGED_FILES=$(git ls-files --full-name | grep ".go$")
 if [[ "$STAGED_FILES" = "" ]]; then
   exit 0
 fi
+
+# Run go lint on the tracked files
 printf "\e[90mRunning golint...\e[0;39m\n"
-# Run go lint on the staged files
 for stagedFile in $STAGED_FILES; do
     # Run golint
     $(golint -set_exit_status $stagedFile)
@@ -29,12 +30,12 @@ if [[ $? != 0 ]]; then
     FAILURE=true
 fi
 
-printf "\e[90mDone! \n"
+# We are done
+printf "\e[90mDone! \e[0;39m\n"
 
 if [[ $FAILURE != false ]]; then
-    printf "\n\e[91mCommit Failed! \n"
+    printf "\n\e[1;91mCommit Failed! \e[0;39m\n"
     exit 1
 fi
-
-printf "\n\e[32mCommit Successful! \n"
+printf "\n\e[1;32mCommit Successful! \e[0;39m\n"
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,32 +10,33 @@ FAILURE=false
 STAGED_FILES=$(git ls-files --full-name | grep ".go$")
 
 if [[ "$STAGED_FILES" = "" ]]; then
+  printf "\e[90mDone! \e[0;39m\n"
   exit 0
 fi
 
 # Run go lint on the tracked files
 printf "\e[90mRunning golint...\e[0;39m\n"
 for stagedFile in $STAGED_FILES; do
-    # Run golint
-    $(golint -set_exit_status $stagedFile)
-    if [[ $? != 0 ]]; then
-        FAILURE=true
-    fi
+  # Run golint
+  $(golint -set_exit_status $stagedFile)
+  if [[ $? != 0 ]]; then
+    FAILURE=true
+  fi
 done
 
 # Run go vet on the entire package, doesn't support single files like lint
 printf "\e[90mRunning go vet...\e[0;39m\n"
 go vet $STAGED_FILES
 if [[ $? != 0 ]]; then
-    FAILURE=true
+  FAILURE=true
 fi
 
 # We are done
 printf "\e[90mDone! \e[0;39m\n"
 
 if [[ $FAILURE != false ]]; then
-    printf "\n\e[1;91mCommit Failed! \e[0;39m\n"
-    exit 1
+  printf "\n\e[1;91mCommit Failed! \e[0;39m\n"
+  exit 1
 fi
 printf "\n\e[1;32mCommit Successful! \e[0;39m\n"
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,19 +6,19 @@ printf "\e[1;93mRunning pre-commit hooks...\e[0;39m \n"
 # Our failure flag
 FAILURE=false
 
-# Get staged go files that we want to run checks on
-STAGED_FILES=$(git ls-files --full-name | grep ".go$")
+# Get tracked go files that we want to run checks on
+TRACKED_FILES=$(git ls-files --full-name | grep ".go$")
 
-if [[ "$STAGED_FILES" = "" ]]; then
+if [[ "$TRACKED_FILES" = "" ]]; then
   printf "\e[90mDone! \e[0;39m\n"
   exit 0
 fi
 
 # Run go lint on the tracked files
 printf "\e[90mRunning golint...\e[0;39m\n"
-for stagedFile in $STAGED_FILES; do
+for trackedFile in $TRACKED_FILES; do
   # Run golint
-  $(golint -set_exit_status $stagedFile)
+  $(golint -set_exit_status $trackedFile)
   if [[ $? != 0 ]]; then
     FAILURE=true
   fi

--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@
 
 ## Enable git hooks when contributing
 
+Git hooks will stop you from committing if there are issues highlighted by `golint` and `go vet`. There are two methods to setting up the githooks, one is using a symlink for older git versions, the other is setting the hooks folder in the local git configuration.
+
 #### Pre-requisites
 
-Install the `golint` and `govet` packages if you don't already have them installed;
+Install the `go vet` and `golint` packages if you don't already have them installed. `govet` is a standard Go package that _should_ come with your Go installation. `golint` however has to be isntalled seperately.
+
 ```sh
 go get -u golang.org/x/lint/golint
 ```
@@ -18,12 +21,14 @@ go get -u golang.org/x/lint/golint
 We can probalby move this to a make make file or something, but for now, this will do i guess.
 This should probably also go in contributing rather than here but, work in progress.
  -->
-**If you are running git 2.9 or higher, do the following;**
 
-Set the permissions on our version controlled githooks
+
+(_Skip for windows users_) Set the permissions on our version controlled githooks.
 ```sh
 chmod -R +x .githooks/*
 ```
+
+**If you are running git 2.9 or higher, do the following;**
 
 Run the following command in the root directory of the project.
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # go-sf
 [WIP] Golang library for Salesforce
+
+----
+
+## Enable git hooks when contributing
+
+#### Pre-requisites
+
+Install the `golint` and `govet` packages if you don't already have them installed;
+```sh
+go get -u golang.org/x/lint/golint
+```
+
+#### Setting up the hooks
+
+<!--
+We can probalby move this to a make make file or something, but for now, this will do i guess.
+This should probably also go in contributing rather than here but, work in progress.
+ -->
+**If you are running git 2.9 or higher, do the following;**
+
+Set the permissions on our version controlled githooks
+```sh
+chmod -R +x .githooks/*
+```
+
+Run the following command in the root directory of the project.
+```sh
+git config --local core.hooksPath .githooks/
+```
+
+**If you are on an older version of git,** run the following to clear out existing symlinks and create new ones;
+
+```sh
+find .git/hooks -type l -exec rm {} \; && find .githooks -type f -exec ln -sf ../../{} .git/hooks/ \;
+```


### PR DESCRIPTION
Adding a shell script pre-commit hook for the library as well as some initial set-up instructions for getting them working.

Examples below, just running the script but if the instructions are following to make the `.githooks` folder the hooks folder for git, it will run.

#### Issues:
It doesn't protect against everything, one thing I have noticed is;

1. I have a `main.go` that is an empty file, I stage that empty file to be committed.
2. I add things to `main.go` and save it, but do not stage the new revision.
3. I run `git commit` and the pre-commit hook runs

I observed that the script is ran against the saved file, which, should fail `go vet` as it is an empty file, but, since it is ran against the currently saved one, the pre-commit hook passes.

*Possible.solution: Do we want to run a `git stash/pop` at the top/bottom of the hook respectively so we run only on the staged changes for the branch?*

## What it looks like

### Success

<img width="711" alt="Screenshot 2019-07-03 at 22 53 34" src="https://user-images.githubusercontent.com/1098786/60627525-40665d00-9de6-11e9-952b-cf8b8f09f7ad.png">

### Failure

<img width="705" alt="Screenshot 2019-07-03 at 22 52 49" src="https://user-images.githubusercontent.com/1098786/60627532-452b1100-9de6-11e9-80e2-cb6025c5bbdb.png">
